### PR TITLE
Add Intermediate CA Support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,12 +20,22 @@
             "label": "test",
             "command": "dotnet",
             "type": "shell",
-            "args": ["test", "${workspaceFolder}/E2ETests/E2ETests.csproj"],
+            "args": [
+                "test",
+                "${workspaceFolder}/E2ETests/E2ETests.csproj"
+            ],
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "type": "dotnet",
+            "task": "build",
             "group": {
-                "kind": "test",
+                "kind": "build",
                 "isDefault": true
             },
-            "problemMatcher": []
+            "problemMatcher": [],
+            "label": "dotnet: build"
         }
     ]
 }

--- a/KeyVaultCA/CsrConfiguration.cs
+++ b/KeyVaultCA/CsrConfiguration.cs
@@ -2,7 +2,9 @@
 {
     public class CsrConfiguration
     {
-        public bool IsRootCA { get; set; }
+        public bool IsRootCA { get; set; } = false;
+
+        public bool IsIntermediateCA { get; set; } = false;
 
         public string Subject { get; set; }
 

--- a/KeyVaultCA/Program.cs
+++ b/KeyVaultCA/Program.cs
@@ -52,7 +52,14 @@ namespace KeyVaultCA
                 }
 
                 // Generate issuing certificate in KeyVault
-                await kvCertProvider.CreateCACertificateAsync(estConfig.IssuingCA, csrConfig.Subject, estConfig.CertPathLength);
+                CertificateConfiguration certConfig = new()
+                {
+                    IssuerCertificateName = estConfig.IssuingCA,
+                    Subject = csrConfig.Subject,
+                    PathLength = estConfig.CertPathLength,
+                    ValidityMonths = estConfig.CertValidityInDays / 30
+                };
+                await kvCertProvider.CreateCACertificateAsync(certConfig);
                 logger.LogInformation("CA certificate was either created successfully or it already existed in the Key Vault {kvUrl}.", estConfig.KeyVaultUrl);
             }
             else

--- a/KeyVaultCA/Program.cs
+++ b/KeyVaultCA/Program.cs
@@ -63,9 +63,9 @@ namespace KeyVaultCA
                     Environment.Exit(1);
                 }
 
-                if (estConfig.CertValidityInDays <= 0 || estConfig.CertValidityInDays > 365)
+                if (estConfig.CertValidityInDays <= 0 || estConfig.CertValidityInDays > estConfig.MaxCertValidity)
                 {
-                    logger.LogError("Number of days specified as the certificate validity period should be between 1 and 365.");
+                    logger.LogError("Number of days specified as the certificate validity period should be between 1 and {maxValid}.", estConfig.MaxCertValidity);
                     Environment.Exit(1);
                 }
 

--- a/KeyVaultCA/Program.cs
+++ b/KeyVaultCA/Program.cs
@@ -71,7 +71,7 @@ namespace KeyVaultCA
 
                 // Issue device certificate
                 var csr = File.ReadAllBytes(csrConfig.PathToCsr);
-                var cert = await kvCertProvider.SignRequestAsync(csr, estConfig.IssuingCA, estConfig.CertValidityInDays);
+                var cert = await kvCertProvider.SignRequestAsync(csr, estConfig.IssuingCA, estConfig.CertValidityInDays, csrConfig.IsIntermediateCA);
 
                 File.WriteAllBytes(csrConfig.OutputFileName, cert.Export(System.Security.Cryptography.X509Certificates.X509ContentType.Cert));
                 logger.LogInformation("Device certificate was created successfully.");

--- a/KeyVaultCA/Program.cs
+++ b/KeyVaultCA/Program.cs
@@ -77,8 +77,13 @@ namespace KeyVaultCA
                 }
 
                 // Issue device certificate
-                var csr = File.ReadAllBytes(csrConfig.PathToCsr);
-                var cert = await kvCertProvider.SignRequestAsync(csr, estConfig.IssuingCA, estConfig.CertValidityInDays, csrConfig.IsIntermediateCA);
+                CertificateConfiguration certConfig = new(){
+                    Csr = File.ReadAllBytes(csrConfig.PathToCsr),
+                    IssuerCertificateName = estConfig.IssuingCA,
+                    ValidityDays = estConfig.CertValidityInDays,
+                    IsIntermediateCA = csrConfig.IsIntermediateCA
+                };
+                var cert = await kvCertProvider.SignRequestAsync(certConfig);
 
                 File.WriteAllBytes(csrConfig.OutputFileName, cert.Export(System.Security.Cryptography.X509Certificates.X509ContentType.Cert));
                 logger.LogInformation("Device certificate was created successfully.");

--- a/KeyVaultCA/appsettings.json
+++ b/KeyVaultCA/appsettings.json
@@ -7,8 +7,8 @@
     "CertPathLength": 1
   },
   "Csr": {
-    "IsRootCA": "<Boolean value. To register a Root CA, value should be true, otherwise false.>",
-    "IsIntermediateCA": "<Boolean value. To sign a CSR for an intermediate CA, value should be true, otherwise false>",
+    "IsRootCA": "false",
+    "IsIntermediateCA": "false",
     "Subject": "<Subject in the format 'C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=Contoso Inc'.>",
     "PathToCsr": "<Path to the CSR file in .der format.>",
     "OutputFileName": "<Output file name for the certificate.>"

--- a/KeyVaultCA/appsettings.json
+++ b/KeyVaultCA/appsettings.json
@@ -7,6 +7,7 @@
   },
   "Csr": {
     "IsRootCA": "<Boolean value. To register a Root CA, value should be true, otherwise false.>",
+    "IsIntermediateCA": "<Boolean value. To sign a CSR for an intermediate CA, value should be true, otherwise false>",
     "Subject": "<Subject in the format 'C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=Contoso Inc'.>",
     "PathToCsr": "<Path to the CSR file in .der format.>",
     "OutputFileName": "<Output file name for the certificate.>"

--- a/KeyVaultCA/appsettings.json
+++ b/KeyVaultCA/appsettings.json
@@ -3,6 +3,7 @@
     "KeyVaultUrl": "<Key Vault URL>",
     "IssuingCA": "<Name of the issuing certificate in KeyVault.>",
     "CertValidityInDays": "365",
+    "MaxCertValidity":"<Integer Value. This is the maximum acceptable validity for a certificate>",
     "CertPathLength": 1
   },
   "Csr": {

--- a/KeyVaultCa.Core/CertificateConfiguration.cs
+++ b/KeyVaultCa.Core/CertificateConfiguration.cs
@@ -1,0 +1,15 @@
+namespace KeyVaultCa.Core
+{
+    public class CertificateConfiguration
+    {
+        public string IssuerCertificateName { get; set; }
+
+        public string Subject { get; set; }
+
+        public int PathLength { get; set; }
+
+        public int ValidityMonths { get; set; }
+
+        public int KeySize { get; set; } = 4096;
+    }
+}

--- a/KeyVaultCa.Core/CertificateConfiguration.cs
+++ b/KeyVaultCa.Core/CertificateConfiguration.cs
@@ -1,7 +1,13 @@
+using System;
+
 namespace KeyVaultCa.Core
 {
     public class CertificateConfiguration
     {
+        public bool IsRootCA {get; set; } = false;
+
+        public bool IsIntermediateCA {get; set; } = false;
+
         public string IssuerCertificateName { get; set; }
 
         public string Subject { get; set; }
@@ -10,6 +16,10 @@ namespace KeyVaultCa.Core
 
         public int ValidityMonths { get; set; }
 
+        public int ValidityDays { get; set; }
+
         public int KeySize { get; set; } = 4096;
+
+        public byte[] Csr { get; set; }
     }
 }

--- a/KeyVaultCa.Core/CertificateConfiguration.cs
+++ b/KeyVaultCa.Core/CertificateConfiguration.cs
@@ -18,7 +18,7 @@ namespace KeyVaultCa.Core
 
         public int ValidityDays { get; set; }
 
-        public int KeySize { get; set; } = 4096;
+        public int KeySize { get; set; } = 2048;
 
         public byte[] Csr { get; set; }
     }

--- a/KeyVaultCa.Core/EstConfiguration.cs
+++ b/KeyVaultCa.Core/EstConfiguration.cs
@@ -8,6 +8,8 @@ namespace KeyVaultCa.Core
 
         public int CertValidityInDays { get; set; }
 
+        public int MaxCertValidity {get; set; } = 730;
+
         public int CertPathLength { get; set; }
     }
 }

--- a/KeyVaultCa.Core/IKeyVaultCertificateProvider.cs
+++ b/KeyVaultCa.Core/IKeyVaultCertificateProvider.cs
@@ -6,7 +6,7 @@ namespace KeyVaultCa.Core
 {
     public interface IKeyVaultCertificateProvider
     {
-        Task CreateCACertificateAsync(string issuerCertificateName, string subject, int certPathLength);
+        Task CreateCACertificateAsync(CertificateConfiguration config);
 
         Task<IList<X509Certificate2>> GetPublicCertificatesByName(IEnumerable<string> certNames);
 

--- a/KeyVaultCa.Core/IKeyVaultCertificateProvider.cs
+++ b/KeyVaultCa.Core/IKeyVaultCertificateProvider.cs
@@ -12,6 +12,6 @@ namespace KeyVaultCa.Core
 
         Task<X509Certificate2> GetCertificateAsync(string issuerCertificateName);
 
-        Task<X509Certificate2> SignRequestAsync(byte[] certificateRequest, string issuerCertificateName, int validityInDays, bool caCert = false);
+        Task<X509Certificate2> SignRequestAsync(CertificateConfiguration config);
     }
 }

--- a/KeyVaultCa.Core/KeyVaultCertificateProvider.cs
+++ b/KeyVaultCa.Core/KeyVaultCertificateProvider.cs
@@ -97,7 +97,7 @@ namespace KeyVaultCa.Core
 
             return await KeyVaultCertFactory.CreateSignedCertificate(
                 info.Subject.ToString(),
-                2048,
+                (ushort)config.KeySize,
                 notBefore,
                 notBefore.AddDays(config.ValidityDays),
                 256,

--- a/KeyVaultCa.Core/KeyVaultCertificateProvider.cs
+++ b/KeyVaultCa.Core/KeyVaultCertificateProvider.cs
@@ -23,13 +23,13 @@ namespace KeyVaultCa.Core
             _logger = logger;
         }
 
-        public async Task CreateCACertificateAsync(string issuerCertificateName, string subject, int certPathLength)
+        public async Task CreateCACertificateAsync(CertificateConfiguration config)
         {
-            var certVersions = await _keyVaultServiceClient.GetCertificateVersionsAsync(issuerCertificateName).ConfigureAwait(false);
+            var certVersions = await _keyVaultServiceClient.GetCertificateVersionsAsync(config.IssuerCertificateName).ConfigureAwait(false);
 
             if (certVersions != 0)
             {
-                _logger.LogInformation("A certificate with the specified issuer name {name} already exists.", issuerCertificateName);
+                _logger.LogInformation("A certificate with the specified issuer name {name} already exists.", config.IssuerCertificateName);
             }
 
             else
@@ -37,14 +37,14 @@ namespace KeyVaultCa.Core
                 _logger.LogInformation("No existing certificate found, starting to create a new one.");
                 var notBefore = DateTime.UtcNow.AddDays(-1);
                 await _keyVaultServiceClient.CreateCACertificateAsync(
-                        issuerCertificateName,
-                        subject,
+                        config.IssuerCertificateName,
+                        config.Subject,
                         notBefore,
-                        notBefore.AddMonths(48),
-                        4096,
+                        notBefore.AddMonths(config.ValidityMonths),
+                        config.KeySize,
                         256,
-                        certPathLength);
-                _logger.LogInformation("A new certificate with issuer name {name} and path length {path} was created succsessfully.", issuerCertificateName, certPathLength);
+                        config.PathLength);
+                _logger.LogInformation("A new certificate with issuer name {name} and path length {path} was created succsessfully.", config.IssuerCertificateName, config.PathLength);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The following common block must be filled in, for all usages of the projects.
 "KeyVault": {
     "KeyVaultUrl": "<Key Vault URL>",
     "IssuingCA": "<Name of the issuing certificate in KeyVault.>",
-    "CertValidityInDays": "<Validity period for issued certificates (maximum is 365 days)>",
+    "CertValidityInDays": "<Validity period for issued certificates>",
+    "MaxCertValidity":"<Maximum validity of issued certificates. CertValidityInDayscannot exceed this value.>",
     "CertPathLength": "<Path length of the certificate chain which gives the maximum number of non-self-issued intermediate certificates that may follow this certificate in a valid certification path. For the Root CA certificate stored in KV, the value should be at least 1, for the others, obtained through the EST server, is sufficient to have 0.>"
   }
 ```
@@ -52,10 +53,30 @@ Run the API Facade like this (feel free to use your own values for the subject):
 ```cd KeyVaultCA```  
 ```dotnet run --Csr:IsRootCA "true" --Csr:Subject "C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=Contoso Inc"``` 
 
+## (Optional) Generate a Intermediate CA in Key Vault
+Generate a CSR for your intermediate CA by using the Azure Portal/CLI/PowerShell Module and getting a CSR _somehow._
+
+1. Once you have a CSR, in order for the script to parse it, you should run
+```openssl req -in <CSR_FILE_PATH> -out <CSR_FILE_PATH>.der -outform DER```
+
+2. Once translated, sign the Intermediate CA with the Root CA. I like to have my Root CA lifetime be 10 years,
+   and my Intermediates 5 years, with the actual certs lasting 1 year. We specify overrides in this command, but 
+   you can modify `KeyVaultCA/appsettings.json` to set defaults.
+```cd KeyVaultCA```
+```dotnet run --Csr:IsIntermediateCA "true" --KeyVault:CertValidityInDays "730" --KeyVault:CertPathLength "1" --Csr:PathToCsr <PATH_TO_CSR_IN_DER_FORMAT> --Csr:OutputFileName <OUTPUT_CERTIFICATE_FILENAME>```
+```openssl x509 -in <OUTPUT_CERTIFICATE_FILENAME> -out <OUTPUT_CERTIFICATE_FILENAME>.pem -outform PEM```
+
+3. Go back to Azure, find the pending IntermediateCA certificate, and upload the Signed PEM certificate
+   using the Merge Signed Response button.
+
+4. Now, you can set your `IssuingCA` in the `appsettings.json` to your new Intermediate CA, and use that
+   to issue certificates.
+
 ## Request a new device certificate
 
-1. First generate the private key:  
-```openssl genrsa -out mydevice.key 2048```  
+1. First generate the private key. It should be noted, if generating this certificate in Azure Key Vault (and therfore 
+    skipping this step), Key Vault only permits EC keys to be used in signatures, not Encipherment or Key Agreement.
+```openssl genrsa -out mydevice.key 4098```  
 
 2. Create the CSR:  
 ```openssl req -new -key mydevice.key -out mydevice.csr```  
@@ -69,6 +90,7 @@ If desired, values can also be set in the `Csr` block of the `appsettings.json`.
 ```
 "Csr": {
     "IsRootCA": "<Boolean value. To register a Root CA, value should be true, otherwise false.>",
+    "IsIntermediateCA": "<Boolean value. To register an Intermediate CA, set to true, otherwise false>",
     "Subject": "<Subject in the format 'C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=Contoso Inc'.>",
     "PathToCsr": "<Path to the CSR file in .der format.>",
     "OutputFileName": "<Output file name for the certificate.>"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Generate a CSR for your intermediate CA by using the Azure Portal/CLI/PowerShell
 openssl req -in <CSR_FILE_PATH> -out <CSR_FILE_PATH>.der -outform DER
 ```
 
-3. Once translated, sign the Intermediate CA with the Root CA. I like to have my Root CA lifetime be 10 years,
+2. Once translated, sign the Intermediate CA with the Root CA. I like to have my Root CA lifetime be 10 years,
   and my Intermediates 5 years, with the actual certs lasting 1 year. We specify overrides in this command, but 
   you can modify `KeyVaultCA/appsettings.json` to set defaults.  
   ```
@@ -95,13 +95,13 @@ openssl req -in <CSR_FILE_PATH> -out <CSR_FILE_PATH>.der -outform DER
 openssl genrsa -out mydevice.key 4098
 ```
 
-3. Create the CSR:  
+2. Create the CSR:  
 ```
 openssl req -new -key mydevice.key -out mydevice.csr
 openssl req -in mydevice.csr -out mydevice.csr.der -outform DER
 ```
 
-4. Run the API Facade and pass all required arguments:   
+3. Run the API Facade and pass all required arguments:   
 ```
 cd KeyVaultCA
 dotnet run --Csr:IsRootCA "false" --Csr:PathToCsr <PATH_TO_CSR_IN_DER_FORMAT> --Csr:OutputFileName <OUTPUT_CERTIFICATE_FILENAME>

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Please refer to [this blog post](https://vslepakov.medium.com/build-a-lightweigh
 # Prerequisites
 
 ## Create an Azure Key Vault:  
-```az keyvault create --name <KEYVAULT_NAME> \```  
-```--resource-group keyvault-ca \```  
-```--enable-soft-delete=true \```  
-```--enable-purge-protection=true```  
+```
+az keyvault create --name <KEYVAULT_NAME> \
+--resource-group keyvault-ca \
+--enable-soft-delete=true \  
+--enable-purge-protection=true
+```  
 
 ## Setup Key Vault access for the Console App
 
@@ -21,13 +23,17 @@ When running locally, they will use the developer authentication and, in the clo
 
 You need to first aquire the object ID of your Azure user:
 
-```az ad user show --id <YOUR_EMAIL_ADDRESS>```
+```
+az ad user show --id <YOUR_EMAIL_ADDRESS>
+```
 
 and then give it accesss to the Key Vault keys and certificates:  
-```az keyvault set-policy --name <KEYVAULT_NAME> \```  
-```--object-id <OBJECT_ID> \```  
-```--key-permissions sign \```  
-``` --certificate-permissions get list update create```  
+```
+az keyvault set-policy --name <KEYVAULT_NAME> \
+--object-id <OBJECT_ID> \
+--key-permissions sign \
+--certificate-permissions get list update create
+```  
 
 # Getting Started
 
@@ -52,16 +58,20 @@ For overriding settings from command line arguments on Linux, use a syntax simil
 ## Generate a new Root CA in Key Vault
 
 Run the API Facade like this (feel free to use your own values for the subject):  
-```cd KeyVaultCA```  
-```dotnet run --Csr:IsRootCA "true" --Csr:Subject "C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=Contoso Inc"``` 
+```
+cd KeyVaultCA
+dotnet run --Csr:IsRootCA "true" --Csr:Subject "C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=Contoso Inc"
+``` 
 
 ## (Optional) Generate a Intermediate CA in Key Vault
 Generate a CSR for your intermediate CA by using the Azure Portal/CLI/PowerShell Module and getting a CSR _somehow._
 
 1. Once you have a CSR, in order for the script to parse it, you should run
-```openssl req -in <CSR_FILE_PATH> -out <CSR_FILE_PATH>.der -outform DER```
+```
+openssl req -in <CSR_FILE_PATH> -out <CSR_FILE_PATH>.der -outform DER
+```
 
-2. Once translated, sign the Intermediate CA with the Root CA. I like to have my Root CA lifetime be 10 years,
+3. Once translated, sign the Intermediate CA with the Root CA. I like to have my Root CA lifetime be 10 years,
   and my Intermediates 5 years, with the actual certs lasting 1 year. We specify overrides in this command, but 
   you can modify `KeyVaultCA/appsettings.json` to set defaults.  
   ```
@@ -78,23 +88,27 @@ Generate a CSR for your intermediate CA by using the Azure Portal/CLI/PowerShell
 
 ## Request a new device certificate
 
-1. First generate the private key. It should be noted, if generating this certificate in Azure Key Vault (and therfore 
-    skipping this step), Key Vault only permits EC keys to be used in signatures, not Encipherment or Key Agreement.
-```openssl genrsa -out mydevice.key 4098```  
-1. First generate the private key. It should be noted, if generating this certificate in Azure Key Vault (and therfore 
-    skipping this step), Key Vault only permits EC keys to be used in signatures, not Encipherment or Key Agreement.
-```openssl genrsa -out mydevice.key 4098```  
+>**Note**: If planning on doing this all through ECC certificates, be aware that Azure KeyVault only allows stored ECC certificates to sign and verify data.
 
-2. Create the CSR:  
-```openssl req -new -key mydevice.key -out mydevice.csr```  
-```openssl req -in mydevice.csr -out mydevice.csr.der -outform DER```
+1. First generate the private key. 
+```
+openssl genrsa -out mydevice.key 4098
+```
 
-3. Run the API Facade and pass all required arguments:   
-```cd KeyVaultCA```  
-```dotnet run --Csr:IsRootCA "false" --Csr:PathToCsr <PATH_TO_CSR_IN_DER_FORMAT> --Csr:OutputFileName <OUTPUT_CERTIFICATE_FILENAME>```
+3. Create the CSR:  
+```
+openssl req -new -key mydevice.key -out mydevice.csr
+openssl req -in mydevice.csr -out mydevice.csr.der -outform DER
+```
 
+4. Run the API Facade and pass all required arguments:   
+```
+cd KeyVaultCA
+dotnet run --Csr:IsRootCA "false" --Csr:PathToCsr <PATH_TO_CSR_IN_DER_FORMAT> --Csr:OutputFileName <OUTPUT_CERTIFICATE_FILENAME>
+```
 If desired, values can also be set in the `Csr` block of the `appsettings.json`.
 ```
+
 "Csr": {
     "IsRootCA": "<Boolean value. To register a Root CA, value should be true, otherwise false.>",
     "IsIntermediateCA": "<Boolean value. To register an Intermediate CA, set to true, otherwise false>",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The following common block must be filled in, for all usages of the projects.
 "KeyVault": {
     "KeyVaultUrl": "<Key Vault URL>",
     "IssuingCA": "<Name of the issuing certificate in KeyVault.>",
-    "CertValidityInDays": "<Validity period for issued certificates (maximum is 365 days)>",
+    "CertValidityInDays": "<Validity period for issued certificates>",
+    "MaxCertValidity":"<Maximum validity of issued certificates. CertValidityInDayscannot exceed this value.>",
     "CertPathLength": "<Path length of the certificate chain which gives the maximum number of non-self-issued intermediate certificates that may follow this certificate in a valid certification path. For the Root CA certificate stored in KV, the value should be at least 1, for the others, obtained through the EST server, is sufficient to have 0.>"
   }
 ```
@@ -52,10 +53,32 @@ Run the API Facade like this (feel free to use your own values for the subject):
 ```cd KeyVaultCA```  
 ```dotnet run --Csr:IsRootCA "true" --Csr:Subject "C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=Contoso Inc"``` 
 
+## (Optional) Generate a Intermediate CA in Key Vault
+Generate a CSR for your intermediate CA by using the Azure Portal/CLI/PowerShell Module and getting a CSR _somehow._
+
+1. Once you have a CSR, in order for the script to parse it, you should run
+```openssl req -in <CSR_FILE_PATH> -out <CSR_FILE_PATH>.der -outform DER```
+
+2. Once translated, sign the Intermediate CA with the Root CA. I like to have my Root CA lifetime be 10 years,
+  and my Intermediates 5 years, with the actual certs lasting 1 year. We specify overrides in this command, but 
+  you can modify `KeyVaultCA/appsettings.json` to set defaults.  
+  ```
+  cd KeyVaultCA
+  dotnet run --Csr:IsIntermediateCA "true" --KeyVault:CertValidityInDays "730" --KeyVault:CertPathLength "1" --Csr:PathToCsr <PATH_TO_CSR_IN_DER_FORMAT> --Csr:OutputFileName <OUTPUT_CERTIFICATE_FILENAME>
+  openssl x509 -in <OUTPUT_CERTIFICATE_FILENAME> -out <OUTPUT_CERTIFICATE_FILENAME>.pem -outform PEM
+  ```
+
+3. Go back to Azure, find the pending IntermediateCA certificate, and upload the Signed PEM certificate
+   using the Merge Signed Response button.
+
+4. Now, you can set your `IssuingCA` in the `appsettings.json` to your new Intermediate CA, and use that
+   to issue certificates.
+
 ## Request a new device certificate
 
-1. First generate the private key:  
-```openssl genrsa -out mydevice.key 2048```  
+1. First generate the private key. It should be noted, if generating this certificate in Azure Key Vault (and therfore 
+    skipping this step), Key Vault only permits EC keys to be used in signatures, not Encipherment or Key Agreement.
+```openssl genrsa -out mydevice.key 4098```  
 
 2. Create the CSR:  
 ```openssl req -new -key mydevice.key -out mydevice.csr```  
@@ -69,6 +92,7 @@ If desired, values can also be set in the `Csr` block of the `appsettings.json`.
 ```
 "Csr": {
     "IsRootCA": "<Boolean value. To register a Root CA, value should be true, otherwise false.>",
+    "IsIntermediateCA": "<Boolean value. To register an Intermediate CA, set to true, otherwise false>",
     "Subject": "<Subject in the format 'C=US, ST=WA, L=Redmond, O=Contoso, OU=Contoso HR, CN=Contoso Inc'.>",
     "PathToCsr": "<Path to the CSR file in .der format.>",
     "OutputFileName": "<Output file name for the certificate.>"


### PR DESCRIPTION
Adds in another parameter to the CsrConfiguration class, that allows us to add the Certificate Sign and CRL Sign usages _without_ triggering the code to create a new Root CA in the key vault.

This allows us to create a RootCA in the keyvault, and then a IntermediateCA CSR that we then sign using that RootCA. I've added this as a parameter, as I want to create that IntermediateCA in the KeyVault too, but that will not always be the case; the Intermediate CA may be an on-prem CA that we have a CSR for.